### PR TITLE
ДЗ Сетевая подсистема Kubernetes

### DIFF
--- a/kubernetes-networks/README.md
+++ b/kubernetes-networks/README.md
@@ -1,0 +1,50 @@
+Домашнее задание 3
+
+- Выполнена установка кластера kind
+- Применена ReplicaSet для сервиса frontend:
+  kubectl apply -f frontend-replicaset.yaml
+
+- Вопрос: Руководствуясь материалами лекции опишите произошедшую ситуацию, почему обновление ReplicaSet не повлекло обновление запущенных pod?
+
+ReplicaSet controller не рестартует поды, а следит за тем, чтобы объявленное количество подов было запущено в каждый момент времени
+
+ - Создан манифест paymentservice-deployment.yaml. Выполнено обновление и роллбек версий приложения, используя deployment:
+Версия 0.00.1:
+kubectl apply -f paymentservice-deployment.yaml
+kubectl get pods -l app=paymentservice -w
+kubectl get pods -l app=paymentservice -o=jsonpath='{.items[0:3].spec.containers[0].image}'
+
+Версия 0.00.2:
+kubectl apply -f paymentservice-deployment.yaml
+kubectl get pods -l app=paymentservice -w
+kubectl get pods -l app=paymentservice -o=jsonpath='{.items[0:3].spec.containers[0].image}'
+
+Rollback на v0.0.1:
+
+rollout kubectl rollout undo deployment paymentservice --to-revision=1 | kubectl get rs -l app=paymentservice -w
+
+- Созданы манифесты для  Blue/Green и Reverse Rolling Update с использованием параметров maxSurge и maxUnavailable
+
+Blue/Green:
+
+kubectl apply -f paymentservice-deployment-bg.yaml
+kubectl get pods -l app=frontend -w
+
+Reverse Rolling Update:
+
+kubectl apply -f paymentservice-deployment-reverse.yaml
+kubectl get pods -l app=frontend -w
+
+- Выполнена работа с настройками readinessProbe и livenessProbe
+- Выполнена установка node-exporter на master и worker nodes используя DaemonSet
+
+kubectl apply -f node-exporter-daemonset.yaml
+kubectl port-forward node-exporter-mzcfw 9100:9100
+curl localhost:9100/metrics
+
+- Для развертывания Node Exporter на master используется tolerations 
+
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule

--- a/kubernetes-networks/metallb-config.yaml
+++ b/kubernetes-networks/metallb-config.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  namespace: metallb-system
+  name: config
+data:
+  config: |
+    address-pools:
+    - name: default
+      protocol: layer2
+      addresses:
+      - "172.17.255.1-172.17.255.255"

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,0 +1,17 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ingress-nginx
+  namespace: ingress-nginx
+  labels:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/component: controller
+spec:
+  externalTrafficPolicy: Local
+  type: LoadBalancer
+  selector:
+    app.kubernetes.io/name: ingress-nginx
+    app.kubernetes.io/component: controller
+  ports:
+    - { name: http, port: 80, targetPort: http }
+    - { name: https, port: 443, targetPort: https }

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -5,13 +5,13 @@ metadata:
   namespace: ingress-nginx
   labels:
     app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/component: controller
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
   selector:
     app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/part-of: ingress-nginx
+    app.kubernetes.io/component: controller
   ports:
-  - { name: http, port: 80, targetPort: http }
-  - { name: https, port: 443, targetPort: https }
+    - { name: http, port: 80, targetPort: http }
+    - { name: https, port: 443, targetPort: https }

--- a/kubernetes-networks/nginx-lb.yaml
+++ b/kubernetes-networks/nginx-lb.yaml
@@ -1,17 +1,17 @@
-kind: Service
 apiVersion: v1
+kind: Service
 metadata:
   name: ingress-nginx
   namespace: ingress-nginx
   labels:
     app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/component: controller
+    app.kubernetes.io/part-of: ingress-nginx
 spec:
   externalTrafficPolicy: Local
   type: LoadBalancer
   selector:
     app.kubernetes.io/name: ingress-nginx
-    app.kubernetes.io/component: controller
+    app.kubernetes.io/part-of: ingress-nginx
   ports:
-    - { name: http, port: 80, targetPort: http }
-    - { name: https, port: 443, targetPort: https }
+  - { name: http, port: 80, targetPort: http }
+  - { name: https, port: 443, targetPort: https }

--- a/kubernetes-networks/web-deploy.yaml
+++ b/kubernetes-networks/web-deploy.yaml
@@ -1,0 +1,44 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+  labels:
+    app: web
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: web
+  template:
+    metadata:
+      name: web
+      labels:
+        app: web
+    spec:
+      containers:
+        - name: web
+          image: oksanazh/hw_web-app:1.0.0
+          readinessProbe:
+            httpGet:
+              path: /index.html
+              port: 8000
+          livenessProbe:
+            tcpSocket: { port: 8000 }
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      initContainers:
+        - name: init-index-page
+          image: busybox:1.31.0
+          command: ['sh', '-c', 'wget -O- https://bit.ly/otus-k8s-index-gen | sh']
+          volumeMounts:
+            - name: app
+              mountPath: /app
+      volumes:
+        - name: app
+          emptyDir: {}
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 0
+      maxSurge: 100%

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: web
+  annotations:
+    nginx.ingress.kubernetes.io/rewrite-target: /
+spec:
+  rules:
+  - http:
+      paths:
+      - path: /web
+        pathType: Prefix
+        backend:
+          service:
+            name: web-svc
+            port:
+              number: 8000

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1
+apiVersion: networking.k8s.io/v1beta1
 kind: Ingress
 metadata:
   name: web
@@ -9,9 +9,6 @@ spec:
   - http:
       paths:
       - path: /web
-        pathType: Prefix
         backend:
-          service:
-            name: web-svc
-            port:
-              number: 8000
+          serviceName: web-svc
+          servicePort: 8000

--- a/kubernetes-networks/web-ingress.yaml
+++ b/kubernetes-networks/web-ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.k8s.io/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: web
@@ -9,6 +9,9 @@ spec:
   - http:
       paths:
       - path: /web
+        pathType: Prefix
         backend:
-          serviceName: web-svc
-          servicePort: 8000
+          service:
+            name: web-svc
+            port: 
+              number: 8000

--- a/kubernetes-networks/web-svc-cip.yaml
+++ b/kubernetes-networks/web-svc-cip.yaml
@@ -1,0 +1,12 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-cip
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000

--- a/kubernetes-networks/web-svc-headless.yaml
+++ b/kubernetes-networks/web-svc-headless.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc
+spec:
+  selector:
+    app: web
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000
+      

--- a/kubernetes-networks/web-svc-lb.yaml
+++ b/kubernetes-networks/web-svc-lb.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: web-svc-lb
+  
+spec:
+  selector:
+    app: web
+  type: LoadBalancer
+  ports:
+    - protocol: TCP
+      port: 80
+      targetPort: 8000


### PR DESCRIPTION
# Выполнено ДЗ №

 - [*] Основное ДЗ
 - [ -] Задание со *

Домашнее задание 4

1. В описание манифеста web-pod.yml добавлен readinessProbe:

          readinessProbe:
            httpGet:
              path: /index.html
              port: 8000

Запущен pod:

kubectl apply -f web-pod.yaml

Проверка статуса pod:

kubectl get pods
NAME   READY   STATUS    RESTARTS   AGE
web    0/1     Running   0          9s

Pod не перешёл в состояние Ready т.к. не прошел проверку готовности(указан port - 80 вместо 8000).

Добавлен livenessProbe:

livenessProbe:
    tcpSocket:
      {port: 8080}

2. На основе kuberneted-intro\web-pod.yaml создан Deployment с измененными readinessProbe и кол-вом реплик

apiVersion: apps/v1
kind: Deployment
metadata:
  name: web
  labels:
    app: web
spec:
  replicas: 3
  selector:
    matchLabels:
      app: web
  template:
    metadata:
      name: web
      labels:
        app: web
    spec:
      containers:
        - name: web
          image: oksanazh/hw_web-app:1.0.0
          readinessProbe:
            httpGet:
              path: /index.html
              port: 8000
          livenessProbe:
            tcpSocket: { port: 8000 }

Применение манифеста:

kubectl apply -f web-deploy.yaml

Описание deployment:

kubectl describe deploy/web

В Condifitions Deployment - Available and Progressing"

Conditions:
  Type           Status  Reason
  ----           ------  ------
  Available      True    MinimumReplicasAvailable
  Progressing    True    NewReplicaSetAvailable

В манифест добалвена стратегия развертывания:

  strategy:
    type: RollingUpdate
    rollingUpdate:
      maxUnavailable: 0
      maxSurge: 100%

При использовании различных вариаций значений параметров maxUnavailable и maxSurge можно получить различные стратегии обновления подов:
Canary  - maxUnavailable: 1 \maxSurge: 0
Blue-Green - maxUnavailable: 0 \maxSurge: 100%
удалить все pod и затем создать новые - maxUnavailable: 100% \maxSurge: 0

3. Создадн манифест для Service с типом ClusterIP: 

kubectl apply -f web-svc-cip.yaml
kubectl get service
NAME          TYPE           CLUSTER-IP       EXTERNAL-IP    PORT(S)        AGE
kubernetes    ClusterIP      10.96.0.1        <none>         443/TCP        153m
web-svc-cip   ClusterIP      10.103.215.124   <none>         80/TCP         94m

Проверен доступ к  ClusterIP

minikube ssh
curl http://0.103.215.124 /index.html
ping 0.103.215.124 
arp -an
ip addr show
sudo iptables --list -nv -t nat

4. Установлен IPVS  и настроен minikube для его использования
5. Установлен MetalLB. Провекра установки:

kubectl --namespace metallb-system get all
6. Настроен MetalLB с использованием ConfigMap (манифест metallb-config.yaml)
7. Создан  Service с MetalLB в качетве LoadBalancer (манифест web-svc-lb.yaml)

kubectl --namespace metallb-system logs pod/controller-7696f658c8-bxp7q:

{"caller":"service.go:114","event":"ipAllocated","ip":"172.17.255.1","msg":"IP address assigned by controller","service":"default/web-svc-lb","ts":"2022-10-13T08:25:14.784174051Z"}

IP 172.17.255.1 назначен сервису web-svc-lb

kubectl describe svc web-svc-lb:

IP:                       10.96.125.130
IPs:                      10.96.125.130
LoadBalancer Ingress:     172.17.255.1

8. создан маршрут с minikube на хост:

minikube ip

172.17.6.227

ip route add 172.17.255.0/24 via 172.17.6.227

Проверен доступ http://172.17.255.1/index.html

9. Создан ingress

Основной манифест:

kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/master/deploy/static/mandatory.yaml

10/ Создан манифест nginx-lb.yaml с конфигурацией балансировщика нагрузки. 

Получен ip адрес

kubectl get svc -n ingress-nginx

NAME                                 TYPE           CLUSTER-IP       EXTERNAL-IP    PORT(S)                      AGE
ingress-nginx                        LoadBalancer   10.110.207.133   172.17.255.3   80:30964/TCP,443:30271/TCP   86m

10. Создан headless-сервис для веб-приложения (web-svc-headless.yaml)

kubectl apply -f web-svc-headless.yaml

11. Создан манифест web-ingress.yaml 

kubectl describe ingress/web:

Name:             web
Namespace:        default
Address:          172.17.255.3
Default backend:  default-http-backend:80 (<none>)
Rules:
Host  Path  Backends
----  ----  --------
*
        /web   web-svc:8000 (172.17.0.7:8000,172.17.0.8:8000,172.17.0.9:8000)
## PR checklist:
 - [*] Выставлен label с темой домашнего задания