### PR TITLE
Review Required: kubernetes-volumes

### DIFF
--- a/kubernetes-volumes/README.md
+++ b/kubernetes-volumes/README.md
@@ -1,0 +1,56 @@
+Домашнее задание 5
+
+Выполнение работы:
+
+    Создан kind кластер.
+
+    kind create cluster
+
+    Создан MinIO на основе манифеста minio-statefulset.yaml:
+
+    kubectl apply -f kubernetes-volumes/minio-statefulset.yaml
+
+  В результате применения конфигурации должно произойти следующее:
+      
+      Запуститься под с MinIO
+      Создаться PVC
+      Динамически создаться PV на этом PVC с помощью дефолотного StorageClass
+
+    Создан Headless Service на основе манифеста minio-headless-service.yamд MinIO изнутри кластера:
+
+    kubectl apply -f kubernetes-volumes/minio-headless-service.yaml
+
+  Проверка:
+
+    kubectl get statefulsets
+
+  NAME    READY   AGE
+  minio   1/1     6m23s 
+
+    kubectl get pods
+
+  NAME      READY   STATUS    RESTARTS   AGE
+  minio-0   1/1     Running   0          6m39s
+
+    kubectl get pvc
+
+     NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+data-minio-0   Bound    pvc-bbeb20c5-ab8f-4f47-9888-69697bfd3177   10Gi       RWO            standard       13m
+
+    kubectl get pv
+
+NAME                                       CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS   CLAIM                  STORAGECLASS   REASON   AGE
+pvc-bbeb20c5-ab8f-4f47-9888-69697bfd3177   10Gi       RWO            Delete           Bound    default/data-minio-0   standard                13m
+
+
+    Задание со *:
+
+    Согласно описанию secrets создан отдельный манифест с секратами - minio-secrets.yaml
+
+    kubectl apply -f minio-secrets.yaml
+    
+   Секреты "зашифрованы" секреты в Base64
+   
+   Модифицирован манифест StatefulSet для использования volume типа secret - minio-statefulset_with_secret.yaml:
+
+   kubectl apply -f minio-statefulset_with_secret.yaml

--- a/kubernetes-volumes/minio-headless-service.yaml
+++ b/kubernetes-volumes/minio-headless-service.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  labels:
+    app: minio
+spec:
+  clusterIP: None
+  ports:
+    - port: 9000
+      name: minio
+  selector:
+    app: minio

--- a/kubernetes-volumes/minio-secrets.yaml
+++ b/kubernetes-volumes/minio-secrets.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  MINIO_ACCESS_KEY: bWluaW8=
+  MINIO_SECRET_KEY: bWluaW8xMjM=
+kind: Secret
+metadata:
+  name: keys

--- a/kubernetes-volumes/minio-statefulset.yaml
+++ b/kubernetes-volumes/minio-statefulset.yaml
@@ -1,0 +1,54 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+      - name: minio
+        env:
+        - name: MINIO_ACCESS_KEY
+          value: "minio"
+        - name: MINIO_SECRET_KEY
+          value: "minio123"
+        image: minio/minio:RELEASE.2019-07-10T00-34-56Z
+        args:
+        - server
+        - /data 
+        ports:
+        - containerPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above. 
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi

--- a/kubernetes-volumes/minio-statefulset_with_secret.yaml
+++ b/kubernetes-volumes/minio-statefulset_with_secret.yaml
@@ -1,0 +1,60 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  # This name uniquely identifies the StatefulSet
+  name: minio
+spec:
+  serviceName: minio
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio # has to match .spec.template.metadata.labels
+  template:
+    metadata:
+      labels:
+        app: minio # has to match .spec.selector.matchLabels
+    spec:
+      containers:
+      - name: minio
+        env:
+        - name: MINIO_ACCESS_KEY
+          valueFrom:
+            secretKeyRef:
+              name: keys
+              key: MINIO_ACCESS_KEY
+        - name: MINIO_SECRET_KEY
+          valueFrom:
+            secretKeyRef:
+              name: keys
+              key: MINIO_SECRET_KEY
+        image: minio/minio:RELEASE.2019-07-10T00-34-56Z
+        args:
+        - server
+        - /data 
+        ports:
+        - containerPort: 9000
+        # These volume mounts are persistent. Each pod in the PetSet
+        # gets a volume mounted based on this field.
+        volumeMounts:
+        - name: data
+          mountPath: /data
+        # Liveness probe detects situations where MinIO server instance
+        # is not working properly and needs restart. Kubernetes automatically
+        # restarts the pods if liveness checks fail.
+        livenessProbe:
+          httpGet:
+            path: /minio/health/live
+            port: 9000
+          initialDelaySeconds: 120
+          periodSeconds: 20
+  # These are converted to volume claims by the controller
+  # and mounted at the paths mentioned above. 
+  volumeClaimTemplates:
+  - metadata:
+      name: data
+    spec:
+      accessModes:
+        - ReadWriteOnce
+      resources:
+        requests:
+          storage: 10Gi


### PR DESCRIPTION
# Выполнено ДЗ № 5. Volumes, Storages, StatefulSetStatefulSet

 - [* ] Основное ДЗ
 - [* ] Задание со *

Домашнее задание 5

Выполнение работы:

Создан kind кластер.

kind create cluster

Создан MinIO на основе манифеста minio-statefulset.yaml:

kubectl apply -f kubernetes-volumes/minio-statefulset.yaml

В результате применения конфигурации должно произойти следующее:

  Запуститься под с MinIO
  Создаться PVC
  Динамически создаться PV на этом PVC с помощью дефолотного StorageClass

Создан Headless Service на основе манифеста minio-headless-service.yamд MinIO изнутри кластера:

kubectl apply -f kubernetes-volumes/minio-headless-service.yaml

Проверка:

kubectl get statefulsets

NAME READY AGE minio 1/1 6m23s

kubectl get pods

NAME READY STATUS RESTARTS AGE minio-0 1/1 Running 0 6m39s

kubectl get pvc

 NAME           STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS   AGE

data-minio-0 Bound pvc-bbeb20c5-ab8f-4f47-9888-69697bfd3177 10Gi RWO standard 13m

kubectl get pv

NAME CAPACITY ACCESS MODES RECLAIM POLICY STATUS CLAIM STORAGECLASS REASON AGE pvc-bbeb20c5-ab8f-4f47-9888-69697bfd3177 10Gi RWO Delete Bound default/data-minio-0 standard 13m

Задание со *:

Согласно описанию secrets создан отдельный манифест с секратами - minio-secrets.yaml

kubectl apply -f minio-secrets.yaml

Секреты "зашифрованы" секреты в Base64

Модифицирован манифест StatefulSet для использования volume типа secret - minio-statefulset_with_secret.yaml:

kubectl apply -f minio-statefulset_with_secret.yaml


## PR checklist:
 - [* ] Выставлен label с темой домашнего задания